### PR TITLE
Create a config file for service

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ meilisearch_stable_os:
   - CentOS 8
   - Debian 9
   - Debian 10
+  - Debian 11
   - Fedora 32
   - Fedora 33
   - Fedora 34
@@ -27,3 +28,42 @@ meilisearch_db_path: '/var/lib/meilisearch'
 meilisearch_listen_ip: 127.0.0.1
 meilisearch_listen_port: 7700
 meilisearch_master_key: 'Y0urVery-S3cureAp1K3y'
+
+# use config file instead of visible master key in ps -ef | grep meilisearch
+# base file: https://raw.githubusercontent.com/meilisearch/meilisearch/latest/config.toml
+# All variables are defined here: https://www.meilisearch.com/docs/learn/configuration/instance_options#environment-variables
+# below the config variables prefixed with "meilisearch_cfg_"
+
+meilisearch_configfile: "/etc/meilisearch.toml"
+
+meilisearch_cfg_http_addr: "{{ meilisearch_listen_ip }}:{{ meilisearch_listen_port }}"
+meilisearch_cfg_env: "production"
+meilisearch_cfg_db_path: "{{ meilisearch_db_path }}/data/"
+meilisearch_cfg_no_analytics: "true"
+meilisearch_cfg_http_payload_size_limit: "100 MB"
+meilisearch_cfg_log_level: "INFO"
+meilisearch_cfg_max_indexing_memory: "2 GiB"
+meilisearch_cfg_max_indexing_threads: 4
+
+meilisearch_cfg_dump_dir: "{{ meilisearch_db_path }}/dumps/"
+meilisearch_cfg_import_dump: "./path/to/my/file.dump"
+meilisearch_cfg_ignore_missing_dump: "false"
+
+meilisearch_cfg_ignore_dump_if_db_exists: "false"
+meilisearch_cfg_schedule_snapshot: "false"
+meilisearch_cfg_snapshot_dir: "{{ meilisearch_db_path }}/snapshots/"
+meilisearch_cfg_import_snapshot: "./path/to/my/snapshot"
+meilisearch_cfg_ignore_missing_snapshot: "false"
+meilisearch_cfg_ignore_snapshot_if_db_exists: "false"
+
+meilisearch_use_ssl: false
+meilisearch_cfg_ssl_auth_path: "./path/to/root"
+meilisearch_cfg_ssl_cert_path: "./path/to/certfile"
+meilisearch_cfg_ssl_key_path: "./path/to/private-key"
+meilisearch_cfg_ssl_ocsp_path: "./path/to/ocsp-file"
+meilisearch_cfg_ssl_require_auth: "false"
+meilisearch_cfg_ssl_resumption: "false"
+meilisearch_cfg_ssl_tickets: "false"
+
+meilisearch_cfg_experimental_enable_metrics: "false"
+meilisearch_cfg_experimental_reduce_indexing_memory_usage: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,14 +38,14 @@
   ansible.builtin.shell: /tmp/meilisearch.sh
   args:
     chdir: /tmp
-    warn: 'false'
+    # warn: 'false'
   when: not meilisearch_status.stat.exists | bool
 
 - name: "Move MeiliSearch Binary into Place."
   ansible.builtin.shell: mv /tmp/meilisearch "{{ meilisearch_exe_path }}"
   args:
     chdir: /tmp
-    warn: 'false'
+    # warn: 'false'
   when: not meilisearch_status.stat.exists | bool
 
 - name: "Ensure Permissions on MeiliSearch Binary."
@@ -57,11 +57,26 @@
 
 - name: "Ensure MeiliSearch DB Directory exists."
   ansible.builtin.file:
-    path: "{{ meilisearch_db_path }}"
+    path: "{{ item }}"
     mode: 0750
     owner: "{{ meilisearch_user }}"
     group: "{{ meilisearch_group }}"
     state: directory
+  loop: 
+    - "{{ meilisearch_db_path }}"
+    - "{{ meilisearch_cfg_db_path }}"
+    - "{{ meilisearch_cfg_dump_dir }}"
+    - "{{ meilisearch_cfg_snapshot_dir }}"
+
+- name: "Copy MeiliSearch config file."
+  ansible.builtin.template:
+    src: config.toml.j2
+    dest: "{{ meilisearch_configfile }}"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart meilisearch
 
 - name: "Copy MeiliSearch systemd unit file into place."
   ansible.builtin.template:

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -1,0 +1,140 @@
+# {{ ansible_managed }}
+
+# This file shows the default configuration of Meilisearch.
+# All variables are defined here: https://www.meilisearch.com/docs/learn/configuration/instance_options#environment-variables
+
+# Designates the location where database files will be created and retrieved.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#database-path
+db_path = "{{ meilisearch_cfg_db_path }}"
+
+# Configures the instance's environment. Value must be either `production` or `development`.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#environment
+env = "{{ meilisearch_cfg_env }}"
+
+# The address on which the HTTP server will listen.
+http_addr = "{{ meilisearch_cfg_http_addr }}"
+
+# Sets the instance's master key, automatically protecting all routes except GET /health.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#master-key
+master_key = "{{ meilisearch_master_key }}"
+
+# Deactivates Meilisearch's built-in telemetry when provided.
+# Meilisearch automatically collects data from all instances that do not opt out using this flag.
+# All gathered data is used solely for the purpose of improving Meilisearch, and can be deleted at any time.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#disable-analytics
+no_analytics = {{ meilisearch_cfg_no_analytics }}
+
+# Sets the maximum size of accepted payloads.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#payload-limit-size
+http_payload_size_limit = "{{ meilisearch_cfg_http_payload_size_limit }}"
+
+# Defines how much detail should be present in Meilisearch's logs.
+# Meilisearch currently supports six log levels, listed in order of increasing verbosity:  `OFF`, `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#log-level
+log_level = "{{ meilisearch_cfg_log_level }}"
+
+# Sets the maximum amount of RAM Meilisearch can use when indexing.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#max-indexing-memory
+# max_indexing_memory = "{{ meilisearch_cfg_max_indexing_memory }}"
+
+# Sets the maximum number of threads Meilisearch can use during indexing.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#max-indexing-threads
+# max_indexing_threads = {{ meilisearch_cfg_max_indexing_threads }}
+
+#############
+### DUMPS ###
+#############
+
+# Sets the directory where Meilisearch will create dump files.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#dump-directory
+dump_dir = "{{ meilisearch_cfg_dump_dir }}"
+
+# Imports the dump file located at the specified path. Path must point to a .dump file.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#import-dump
+# import_dump = "{{ meilisearch_cfg_import_dump }}"
+
+# Prevents Meilisearch from throwing an error when `import_dump` does not point to a valid dump file.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ignore-missing-dump
+ignore_missing_dump = {{ meilisearch_cfg_ignore_missing_dump }}
+
+# Prevents a Meilisearch instance with an existing database from throwing an error when using `import_dump`.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ignore-dump-if-db-exists
+ignore_dump_if_db_exists = {{ meilisearch_cfg_ignore_dump_if_db_exists }}
+
+
+#################
+### SNAPSHOTS ###
+#################
+
+# Enables scheduled snapshots when true, disable when false (the default).
+# If the value is given as an integer, then enables the scheduled snapshot with the passed value as the interval
+# between each snapshot, in seconds.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#schedule-snapshot-creation
+schedule_snapshot = {{ meilisearch_cfg_schedule_snapshot }}
+
+# Sets the directory where Meilisearch will store snapshots.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#snapshot-destination
+snapshot_dir = "{{ meilisearch_cfg_snapshot_dir }}"
+
+# Launches Meilisearch after importing a previously-generated snapshot at the given filepath.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#import-snapshot
+# import_snapshot = "{{ meilisearch_cfg_import_snapshot }}"
+
+# Prevents a Meilisearch instance from throwing an error when `import_snapshot` does not point to a valid snapshot file.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ignore-missing-snapshot
+ignore_missing_snapshot = {{ meilisearch_cfg_ignore_missing_snapshot }}
+
+# Prevents a Meilisearch instance with an existing database from throwing an error when using `import_snapshot`.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ignore-snapshot-if-db-exists
+ignore_snapshot_if_db_exists = {{ meilisearch_cfg_ignore_snapshot_if_db_exists }}
+
+
+###########
+### SSL ###
+###########
+
+{% if meilisearch_use_ssl is true %}
+
+# Enables client authentication in the specified path.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ssl-authentication-path
+ssl_auth_path = ".{{ meilisearch_cfg_ssl_auth_path }}"
+
+# Sets the server's SSL certificates.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ssl-certificates-path
+ssl_cert_path = "{{ meilisearch_cfg_ssl_cert_path }}"
+
+# Sets the server's SSL key files.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ssl-key-path
+ssl_key_path = "{{ meilisearch_cfg_ssl_key_path }}"
+
+# Sets the server's OCSP file.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ssl-ocsp-path
+ssl_ocsp_path = "{{ meilisearch_cfg_ssl_ocsp_path }}"
+
+# Makes SSL authentication mandatory.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ssl-require-auth
+ssl_require_auth = {{ meilisearch_cfg_ssl_require_auth }}
+
+# Activates SSL session resumption.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ssl-resumption
+ssl_resumption = {{ meilisearch_cfg_ssl_resumption }}
+
+# Activates SSL tickets.
+# https://www.meilisearch.com/docs/learn/configuration/instance_options#ssl-tickets
+ssl_tickets = {{ meilisearch_cfg_ssl_tickets }}
+
+{% else %}
+# INFO: meilisearch_use_ssl is set to false - skipping SSL section
+{% endif %}
+
+
+#############################
+### Experimental features ###
+#############################
+
+# Experimental metrics feature. For more information, see: <https://github.com/meilisearch/meilisearch/discussions/3518>
+# Enables the Prometheus metrics on the `GET /metrics` endpoint.
+experimental_enable_metrics = {{ meilisearch_cfg_experimental_enable_metrics }}
+
+# Experimental RAM reduction during indexing, do not use in production, see: <https://github.com/meilisearch/product/discussions/652>
+experimental_reduce_indexing_memory_usage = {{ meilisearch_cfg_experimental_reduce_indexing_memory_usage }}

--- a/templates/meilisearch.unit.j2
+++ b/templates/meilisearch.unit.j2
@@ -8,7 +8,11 @@ After=systemd-user-sessions.service
 Type=simple
 User={{ meilisearch_user }}
 Group={{ meilisearch_group }}
-ExecStart={{ meilisearch_exe_path }} --http-addr {{ meilisearch_listen_ip }}:{{ meilisearch_listen_port }} --db-path {{ meilisearch_db_path }} --master-key {{ meilisearch_master_key }} --env production --no-analytics true
+
+# hahn: added - it prevents Error: Permission denied (os error 13)
+WorkingDirectory={{ meilisearch_db_path }}
+
+ExecStart={{ meilisearch_exe_path }} --config-file-path {{ meilisearch_configfile }}
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Hi @thorian93 

Thanks for providing this ansible role!

There were 2 issues in systemd config file:
* `--no-analytics true` is wrong: new syntax would be without "true"
* I got `Permission denied (os error 13)` while starting service: I added a writable working directory.

I added a config file. Especially because of visible master key in ps -ef | grep meilisearch.
My base file is from here: https://raw.githubusercontent.com/meilisearch/meilisearch/latest/config.toml
All variables are defined here: https://www.meilisearch.com/docs/learn/configuration/instance_options#environment-variables
As defaults I named config variables with prefix "meilisearch_cfg_".

Kind regards,
Axel